### PR TITLE
Fix: Ensure code command works on Windows with subprocess.run

### DIFF
--- a/rcode/rcode.py
+++ b/rcode/rcode.py
@@ -7,6 +7,7 @@ import os
 import subprocess as sp
 import time
 import subprocess
+import sys
 from distutils.spawn import find_executable
 from functools import partial
 from pathlib import Path
@@ -203,13 +204,14 @@ def run_loacl(
     rcode_home = Path.home() / ".rcode"
     ssh_remote = "vscode-remote://ssh-remote+{remote_name}{remote_dir}"
     rcode_used_list = []
+    is_win = sys.platform == "win32"
     if os.path.exists(rcode_home):
         with open(rcode_home) as f:
-            rcode_used_list = list(f.read().splitlines())
+            rcode_used_list = list(filter(len, f.read().splitlines()))
     if is_latest:
         if rcode_used_list:
             ssh_remote_latest = rcode_used_list[-1].split(",")[-1].strip()
-            proc = sp.run([bin_name, "--folder-uri", ssh_remote_latest])
+            proc = sp.run([bin_name, "--folder-uri", ssh_remote_latest], shell=is_win)
             exit(proc.returncode)
         else:
             print("Not use rcode before, just use it once")
@@ -218,7 +220,7 @@ def run_loacl(
         for l in rcode_used_list:
             name, server = l.split(",")
             if open_shortcut_name.strip() == name.strip():
-                proc = sp.run([bin_name, "--folder-uri", server.strip()])
+                proc = sp.run([bin_name, "--folder-uri", server.strip()], shell=is_win)
                 # then add it to the latest
                 with open(rcode_home, "a") as f:
                     f.write(f"latest,{server}{str(os.linesep)}")
@@ -244,7 +246,7 @@ def run_loacl(
         else:
             f.write(f"latest,{ssh_remote}{str(os.linesep)}")
 
-    proc = sp.run([bin_name, "--folder-uri", ssh_remote])
+    proc = sp.run([bin_name, "--folder-uri", ssh_remote], shell=is_win)
     exit(proc.returncode)
 
 


### PR DESCRIPTION
On Windows, the `code` command is typically available in PowerShell due to automatic path resolution and `.cmd` file handling. However, when using Python's `subprocess.run`, the command fails with `FileNotFoundError` because:
1. **PowerShell Behavior**: PowerShell automatically resolves `code` to `code.cmd` (located in the VS Code installation directory) and handles its execution.
2. **Python `subprocess.run` Behavior**: By default, `subprocess.run` does not use the Shell environment (`cmd.exe` or PowerShell) and cannot resolve `.cmd` files or aliases. As a result, it fails to locate or execute `code.cmd`.

#### **Solution**
To ensure compatibility across platforms, the following changes were made:
1. **Windows**: Use `shell=True` in `subprocess.run` to execute the command through the Shell (`cmd.exe`), which correctly resolves `.cmd` files and the `PATH` environment variable.
   ```python
   subprocess.run(["code", "--folder-uri", uri], shell=True)
   ```
2. **Linux/macOS**: Call the `code` command with `shell=False`, as it is typically available in the system `PATH` and does not require Shell-specific resolution.
